### PR TITLE
Upgrade Microsoft.WindowsAppSDK to version 1.7.251107005

### DIFF
--- a/ThreeFingersDragOnWindows/ThreeFingersDragOnWindows.csproj
+++ b/ThreeFingersDragOnWindows/ThreeFingersDragOnWindows.csproj
@@ -106,7 +106,7 @@
     <ItemGroup>
         <PackageReference Include="H.NotifyIcon.WinUI" Version="2.0.118" />
         <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.251107005" />
         <PackageReference Include="TaskScheduler" Version="2.10.1" />
         <PackageReference Include="WinUICommunity.Components" Version="5.3.0" />
         <PackageReference Include="WinUICommunity.Core" Version="5.3.1" />


### PR DESCRIPTION
Changed the SDK dependencies to last 1.7.
1.8 seems to now include a specific exclusion of .net6 framework and I lack knowledge of WebUI to update all the components.  